### PR TITLE
Changed output variable to global

### DIFF
--- a/train.py
+++ b/train.py
@@ -17,9 +17,10 @@ import argparse
 nst = model.nst_model
 loader = utils.loader
 imshow = utils.imshow
+output = None
 
 def main(args):
-
+    global output
     content_img = args.content_img
     style_img = args.style_img
     size = args.size
@@ -38,6 +39,7 @@ def main(args):
     step = [0]
     while step[0] <= steps:
         def closure():
+            global output
             input_img.data.clamp_(0, 1)
             optimizer.zero_grad()
             output = model(input_img)


### PR DESCRIPTION
Because 'output' was local variable, your system was not able to show the result image. Changed output variable to global variable and fixed the issue.
output 변수가 local 이라서 `imshow(output, title = 'Output Image')`에서 오류가 있었습니다. output 변수를 global로 바꿔서 해결했습니다.